### PR TITLE
Script Syslinux Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After that simply run the below script. It doesn't require root privileges. In t
     cp ../syslinux-6.03/bios/core/isolinux.bin .
     cp ../syslinux-6.03/bios/com32/elflink/ldlinux/ldlinux.c32 .
     cp kernel ./kernel.xz
-    cp ../rootfs.cpio.xz ./rootfs.xz
+    cp ../rootfs.cpio.gz ./rootfs.xz
     echo 'default kernel.xz  initrd=rootfs.xz' > ./isolinux.cfg
     genisoimage \
     	-J \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ After that simply run the below script. It doesn't require root privileges. In t
     cp ../syslinux-6.03/bios/com32/elflink/ldlinux/ldlinux.c32 .
     cp kernel ./kernel.xz
     cp ../rootfs.cpio.xz ./rootfs.xz
-    echo 'default kernel.xz  initrd=rootfs.xz vga=ask' > ./isolinux.cfg
+    echo 'default kernel.xz  initrd=rootfs.xz' > ./isolinux.cfg
     genisoimage \
     	-J \
     	-r \

--- a/README.md
+++ b/README.md
@@ -52,5 +52,6 @@ After that simply run the below script. It doesn't require root privileges. In t
     	-boot-info-table \
     	./
     isohybrid -u ../minimal_linux_live.iso 2>/dev/null || true
+    cd ..
 
 Note that this produces very small live Linux OS with working shell only. The network support has been implemented properly in the [Minimal Linux Live](http://github.com/ivandavidov/minimal) project which is extensively documented and more feature rich, yet still produces very small live Linux ISO image.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ The script below uses **Linux kernel 4.7.2** and **BusyBox 1.24.2**. The source 
 
 After that simply run the below script. It doesn't require root privileges. In the end you should have a bootable ISO image named `minimal_linux_live.iso` in the same directory where you executed the script.
 
-    wget http://kernel.org/pub/linux/kernel/v4.x/linux-4.7.2.tar.xz
+    wget http://kernel.org/pub/linux/kernel/v4.x/linux-4.7.6.tar.xz
     wget http://busybox.net/downloads/busybox-1.24.2.tar.bz2
-    tar -xvf linux-4.7.2.tar.xz
+    wget http://kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.xz
+    mkdir isoimage
+    tar -xvf linux-4.7.6.tar.xz
     tar -xvf busybox-1.24.2.tar.bz2
+    tar -xvf syslinux-6.03.tar.xz
     cd busybox-1.24.2
     make distclean defconfig
     sed -i "s/.*CONFIG_STATIC.*/CONFIG_STATIC=y/" .config
@@ -26,10 +29,28 @@ After that simply run the below script. It doesn't require root privileges. In t
     echo 'setsid cttyhack /bin/sh' >> init
     chmod +x init
     find . | cpio -R root:root -H newc -o | gzip > ../../rootfs.cpio.gz
-    cd ../../linux-4.7.2
+    cd ../../linux-4.7.6
     make mrproper defconfig bzImage
-    make isoimage FDINITRD=../rootfs.cpio.gz
-    cp arch/x86/boot/image.iso ../minimal_linux_live.iso
+    cp arch/x86/boot/bzImage \
+    	../isoimage/kernel
     cd ..
+    cd isoimage
+    cp ../syslinux-6.03/bios/core/isolinux.bin .
+    cp ../syslinux-6.03/bios/com32/elflink/ldlinux/ldlinux.c32 .
+    cp kernel ./kernel.xz
+    cp ../rootfs.cpio.xz ./rootfs.xz
+    echo 'default kernel.xz  initrd=rootfs.xz vga=ask' > ./isolinux.cfg
+    genisoimage \
+    	-J \
+    	-r \
+    	-o ../minimal_linux_live.iso \
+    	-b isolinux.bin \
+    	-c boot.cat \
+    	-input-charset UTF-8 \
+    	-no-emul-boot \
+    	-boot-load-size 4 \
+    	-boot-info-table \
+    	./
+    isohybrid -u ../minimal_linux_live.iso 2>/dev/null || true
 
 Note that this produces very small live Linux OS with working shell only. The network support has been implemented properly in the [Minimal Linux Live](http://github.com/ivandavidov/minimal) project which is extensively documented and more feature rich, yet still produces very small live Linux ISO image.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Minimal Linux Script
 One script which generates fully functional live Linux ISO image with minimal effort (less than 25 lines of code). This is based on the first published version of [Minimal Linux Live](http://github.com/ivandavidov/minimal) with some minor improvements taken from the next releases. All empty lines and comments have been removed and the script has been modified to reduce the overall length.
 
-The script below uses **Linux kernel 4.7.2** and **BusyBox 1.24.2**. The source bundles are downloaded and compiled automatically. If you are using [Ubuntu](http://ubuntu.com) or [Linux Mint](http://linuxmint.com), you should be able to resolve all build dependencies by executing the following command:
+The script below uses **Linux kernel 4.7.6**, **BusyBox 1.24.2** and **Syslinux 6.03**. The source bundles are downloaded and compiled automatically. If you are using [Ubuntu](http://ubuntu.com) or [Linux Mint](http://linuxmint.com), you should be able to resolve all build dependencies by executing the following command:
 
     sudo apt-get install wget bc build-essential gawk syslinux genisoimage
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ After that simply run the below script. It doesn't require root privileges. In t
     	-no-emul-boot \
     	-boot-load-size 4 \
     	-boot-info-table \
+        -joliet-long \
     	./
     isohybrid -u ../minimal_linux_live.iso 2>/dev/null || true
     cd ..

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Minimal Linux Script
 One script which generates fully functional live Linux ISO image with minimal effort (less than 25 lines of code). This is based on the first published version of [Minimal Linux Live](http://github.com/ivandavidov/minimal) with some minor improvements taken from the next releases. All empty lines and comments have been removed and the script has been modified to reduce the overall length.
 
-The script below uses **Linux kernel 4.6.2** and **BusyBox 1.24.2**. The source bundles are downloaded and compiled automatically. If you are using [Ubuntu](http://ubuntu.com) or [Linux Mint](http://linuxmint.com), you should be able to resolve all build dependencies by executing the following command:
+The script below uses **Linux kernel 4.7.2** and **BusyBox 1.24.2**. The source bundles are downloaded and compiled automatically. If you are using [Ubuntu](http://ubuntu.com) or [Linux Mint](http://linuxmint.com), you should be able to resolve all build dependencies by executing the following command:
 
     sudo apt-get install wget bc build-essential gawk syslinux genisoimage
 
 After that simply run the below script. It doesn't require root privileges. In the end you should have a bootable ISO image named `minimal_linux_live.iso` in the same directory where you executed the script.
 
-    wget http://kernel.org/pub/linux/kernel/v4.x/linux-4.6.2.tar.xz
+    wget http://kernel.org/pub/linux/kernel/v4.x/linux-4.7.2.tar.xz
     wget http://busybox.net/downloads/busybox-1.24.2.tar.bz2
-    tar -xvf linux-4.6.2.tar.xz
+    tar -xvf linux-4.7.2.tar.xz
     tar -xvf busybox-1.24.2.tar.bz2
     cd busybox-1.24.2
     make distclean defconfig
@@ -25,8 +25,8 @@ After that simply run the below script. It doesn't require root privileges. In t
     echo 'mount -t sysfs none /sys' >> init
     echo 'setsid cttyhack /bin/sh' >> init
     chmod +x init
-    find . | cpio -R +0:+0 -H newc -o | gzip > ../../rootfs.cpio.gz
-    cd ../../linux-4.6.2
+    find . | cpio -R root:root -H newc -o | gzip > ../../rootfs.cpio.gz
+    cd ../../linux-4.7.2
     make mrproper defconfig bzImage
     make isoimage FDINITRD=../rootfs.cpio.gz
     cp arch/x86/boot/image.iso ../minimal_linux_live.iso


### PR DESCRIPTION
Due to a change in the Linux Kernel starting with 4.6.2+, an attempt to fix the missing dependency of ldlinux.c32/syslinux is added, but instead ends up breaking the kernel completely with this script. What I did to fix this was to use the .iso creation process used in the normal Minimal Linux Live project, which manually adds the Syslinux Dependencies onto the .iso. Also by using genisoimage instead of directly building from the kernel, it gives people more room to add to the Rootfs, Kernel, etc. Also one minor fix was changing "find . | cpio -R **+0:+0** -H newc -o | gzip > ../../rootfs.cpio.gz" to "find . | cpio -R **root:root** -H newc -o | gzip > ../../rootfs.cpio.gz" due to it not compiling without root being the value. It's your call if you want to merge this or not, but it future-proofs the Linux Kernel for now. 
