### PR TITLE
Replaced genisoimage with xorriso command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ After that simply run the below script. It doesn't require root privileges. In t
         -no-emul-boot \
         -boot-load-size 4 \
         -boot-info-table \
-    ./
+        ./
     cd ..
 
 Note that this script produces very small live Linux OS with working shell only and no network support. The network functionality has been implemented properly in the [Minimal Linux Live](http://github.com/ivandavidov/minimal) project which is extensively documented and more feature rich, yet still produces very small live Linux ISO image.

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ After that simply run the below script. It doesn't require root privileges. In t
     cp ../syslinux-6.03/bios/com32/elflink/ldlinux/ldlinux.c32 .
     echo 'default kernel.gz initrd=rootfs.gz' > ./isolinux.cfg
     xorriso \
-    -as mkisofs \
-    -o ../minimal_linux_live.iso \
-    -b isolinux.bin \
-    -c boot.cat \
-    -no-emul-boot \
-    -boot-load-size 4 \
-    -boot-info-table \
+        -as mkisofs \
+        -o ../minimal_linux_live.iso \
+        -b isolinux.bin \
+        -c boot.cat \
+        -no-emul-boot \
+        -boot-load-size 4 \
+        -boot-info-table \
     ./
     cd ..
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ One script which generates fully functional live Linux ISO image with minimal ef
 
 The script below uses **Linux kernel 4.7.6**, **BusyBox 1.24.2** and **Syslinux 6.03**. The source bundles are downloaded and compiled automatically. If you are using [Ubuntu](http://ubuntu.com) or [Linux Mint](http://linuxmint.com), you should be able to resolve all build dependencies by executing the following command:
 
-    sudo apt-get install wget bc build-essential gawk genisoimage
+    sudo apt-get install wget bc build-essential gawk xorriso
 
 After that simply run the below script. It doesn't require root privileges. In the end you should have a bootable ISO image named `minimal_linux_live.iso` in the same directory where you executed the script.
 

--- a/README.md
+++ b/README.md
@@ -39,18 +39,15 @@ After that simply run the below script. It doesn't require root privileges. In t
     cp ../syslinux-6.03/bios/core/isolinux.bin .
     cp ../syslinux-6.03/bios/com32/elflink/ldlinux/ldlinux.c32 .
     echo 'default kernel.gz initrd=rootfs.gz' > ./isolinux.cfg
-    genisoimage \
-        -J \
-        -r \
-        -o ../minimal_linux_live.iso \
-        -b isolinux.bin \
-        -c boot.cat \
-        -input-charset UTF-8 \
-        -no-emul-boot \
-        -boot-load-size 4 \
-        -boot-info-table \
-        -joliet-long \
-        ./
+    xorriso \
+    -as mkisofs \
+    -o ../minimal_linux_live.iso \
+    -b isolinux.bin \
+    -c boot.cat \
+    -no-emul-boot \
+    -boot-load-size 4 \
+    -boot-info-table \
+    ./
     cd ..
 
 Note that this script produces very small live Linux OS with working shell only and no network support. The network functionality has been implemented properly in the [Minimal Linux Live](http://github.com/ivandavidov/minimal) project which is extensively documented and more feature rich, yet still produces very small live Linux ISO image.

--- a/minimal.sh
+++ b/minimal.sh
@@ -40,7 +40,7 @@ xorriso \
   -no-emul-boot \
   -boot-load-size 4 \
   -boot-info-table \
-./
+  ./
 cd ..
 set +ex
 

--- a/minimal.sh
+++ b/minimal.sh
@@ -34,12 +34,9 @@ cp ../syslinux-$SYSLINUX_VERSION/bios/com32/elflink/ldlinux/ldlinux.c32 .
 echo 'default kernel.gz initrd=rootfs.gz' > ./isolinux.cfg
 xorriso \
   -as mkisofs \
-  -R \
-  -r \
   -o ../minimal_linux_live.iso \
   -b isolinux.bin \
   -c boot.cat \
-  -input-charset UTF-8 \
   -no-emul-boot \
   -boot-load-size 4 \
   -boot-info-table \

--- a/minimal.sh
+++ b/minimal.sh
@@ -32,18 +32,18 @@ cd ../isoimage
 cp ../syslinux-$SYSLINUX_VERSION/bios/core/isolinux.bin .
 cp ../syslinux-$SYSLINUX_VERSION/bios/com32/elflink/ldlinux/ldlinux.c32 .
 echo 'default kernel.gz initrd=rootfs.gz' > ./isolinux.cfg
-genisoimage \
-    -J \
-    -r \
-    -o ../minimal_linux_live.iso \
-    -b isolinux.bin \
-    -c boot.cat \
-    -input-charset UTF-8 \
-    -no-emul-boot \
-    -boot-load-size 4 \
-    -boot-info-table \
-    -joliet-long \
-    ./
+xorriso \
+  -as mkisofs \
+  -R \
+  -r \
+  -o ../minimal_linux_live.iso \
+  -b isolinux.bin \
+  -c boot.cat \
+  -input-charset UTF-8 \
+  -no-emul-boot \
+  -boot-load-size 4 \
+  -boot-info-table \
+./
 cd ..
 set +ex
 


### PR DESCRIPTION
Since I switched from Ubuntu to Void Linux, building MLS kept failing because there's no genisoimage package available for Void. Seems you forgot to copy over the xorriso command from MLL to this, so I fixed that.